### PR TITLE
Fix runtime error when creating vector tiles for Polyline variants

### DIFF
--- a/lib/tile.dart
+++ b/lib/tile.dart
@@ -53,7 +53,7 @@ addFeature(SimpTile tile, feature, tolerance, options) {
     var tags;
     if( feature.tags != null ) tags = feature.tags;
 
-    if (type == FeatureType.LineString && options['lineMetrics']) {
+    if (type == FeatureType.LineString && options.lineMetrics) {
       tags = {};
       feature.tags.forEach((key, val) {
         tags[key] = feature.tags[key];


### PR DESCRIPTION
Leftover remnant of when Maps were used to hold options data and the current options class does not allow for the indexing of properties which results in a exception at runtime.